### PR TITLE
fix exclude modules: add tests & examples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ build-backend = "setuptools.build_meta"
 include-package-data = true
 
 [tool.setuptools.packages.find]
-exclude = ["docs"]
+exclude = ["docs","tests","examples"]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     long_description=open("pypi-readme.rst").read(),
     license="MIT",
     keywords="PDF report web jinja weasyprint",
-    packages=find_packages(exclude="docs"),
+    packages=find_packages(exclude=["docs","tests","examples"]),
     include_package_data=True,
     install_requires=[
         "pypugjs",


### PR DESCRIPTION
Both `pdf-reports` and `sequenticon` are creating "modules" for `examples` and `tests`. This seems erroneous, and in fact they end up clobbering each other. Neither of these should be doing this (packages should stick to their namespace).
